### PR TITLE
Add `Deploy to Swifton.me`-Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ You may get this error after updating TodoApp:
 error: The dependency graph could not be satisfied because an update to...
 ```
 Simply remove ```Packages``` directory with command ```rm -r Packages``` and rebuild with ```swift build```
+
+## Try it out now!
+
+Just try it out by deploying to Swifton.me (not affiliated with [Swifton](https://github.com/necolt/Swifton)).
+
+[![Deploy to Swifton.me](https://serve.swifton.me/badge.png)](https://serve.swifton.me/oneclick?repository=https://github.com/necolt/Swifton-TodoApp)


### PR DESCRIPTION
My open-source project `Swifton.me` is a lightweight and hassle-free Heroku-like Swift PaaS.
I'd like to add this Badge to let users try it out without registration etc.

See https://serve.swifton.me for more infos.
